### PR TITLE
Allow replacements to be specified in with-stub.

### DIFF
--- a/src/bond/james.clj
+++ b/src/bond/james.clj
@@ -34,11 +34,16 @@
      (do ~@body)))
 
 (defmacro with-stub
-  "Takes a vector of fn vars. Replaces each fn with one that takes any
-  number of args and returns nil. Also spies the stubbed-fn"
+  "Takes a vector of fn vars and/or [fn replacement] vectors.
+
+  Replaces each fn with it's replacement. If a replacement is not specified for
+  a fn it's replaced with one that takes any number of args and returns nil.
+  Also spies the stubbed-fn"
   [vs & body]
 
   `(with-redefs ~(->> (mapcat (fn [v]
-                                [v `(spy (constantly nil))]) vs)
+                                (if (vector? v)
+                                  [(first v) `(spy ~(second v))]
+                                  [v `(spy (constantly nil))])) vs)
                       (vec))
      ~@body))

--- a/test/bond/test/james.clj
+++ b/test/bond/test/james.clj
@@ -1,5 +1,5 @@
 (ns bond.test.james
-  (:require [clojure.test :refer (deftest is)]
+  (:require [clojure.test :refer (deftest is testing)]
             [bond.james :as bond]))
 
 
@@ -18,3 +18,13 @@
          (with-out-str
            (bond/with-stub [bar]
              (bar 3))))))
+
+(deftest stub-with-replacement-works []
+  (bond/with-stub [foo
+                   [bar #(str "arg is " %)]]
+    (testing "stubbing works"
+      (is (nil? (foo 4)))
+      (is (= "arg is 3" (bar 3))))
+    (testing "spying works"
+      (is (= [4] (-> foo bond/calls first :args)))
+      (is (= [3] (-> bar bond/calls first :args))))))


### PR DESCRIPTION
Basically just a (with-redefs foo (bond/spy bar) ... ) but a little tidier.

Useful when unit-testing integration points, where the function needs to return a value for the code being tested to continue, calling the function is undesirable because of side-effects, but validating the function was called correctly is still a useful test.