### PR TITLE
James Bond learns how to set traps.

### DIFF
--- a/src/bond/james.clj
+++ b/src/bond/james.clj
@@ -47,3 +47,18 @@
                                   [v `(spy (constantly nil))])) vs)
                       (vec))
      ~@body))
+
+(defmacro with-trap
+  "Calls body with the vector of fn vars stubbed and throws an exception if
+  any of the stubbed fuctions were called when executing body.
+
+  The exception that is thrown is an ex-info object. To inspect the arguments
+  that were passed to the function to which a trap was added, you can inspect
+  the :calls key of the ex-data of the thrown exception."
+  [vs & body]
+  `(with-stub ~vs
+     (let [result# (do ~@body)]
+       (doseq [v# ~vs]
+         (when (-> v# calls count pos?)
+           (throw (ex-info "fn was called" {:calls (calls v#)}))))
+       result#)))

--- a/test/bond/test/james.clj
+++ b/test/bond/test/james.clj
@@ -5,7 +5,10 @@
 
 (defn foo [x] (* 2 x))
 
-(defn bar [x] (println "bar!") (* 2 x))
+(defn bar [x] (* 2 x))
+
+(defn qux [x y]
+  (bar (+ x (foo y))))
 
 (deftest spy-works []
   (bond/with-spy [foo]
@@ -28,3 +31,20 @@
     (testing "spying works"
       (is (= [4] (-> foo bond/calls first :args)))
       (is (= [3] (-> bar bond/calls first :args))))))
+
+
+(deftest with-trap-works
+  (testing "the result is returned when the trap is not triggered"
+    (is (= 6 (bond/with-trap [foo]
+               (bar 3)))))
+  (testing "the macro works when there are no fns supplied"
+    (bond/with-trap []
+      (+ 1 2)))
+  (testing "the trap works when the fn is called"
+    (let [e (is (thrown-with-msg?
+                  clojure.lang.ExceptionInfo #"fn was called"
+                  (bond/with-trap [bar]
+                    (qux 3 7))))]
+      (testing "and args are recorded"
+        (is (= {:calls [{:args [17] :return nil}]}
+               (ex-data e)))))))


### PR DESCRIPTION
Add a new macro, with-trap that throws and exception is any of the
supplied functions are called.

The rational for addign this macro is to avoid this common pattern when
testing Clojure:

```
(bond/with-stub [foo]
  (bar)
  (is (zero? (foo bond/calls count))))
```

This can be replaced with the following:

```
(bond/with-trap [foo]
  (bar)
```

If foo is not called by bar in this example, then the code will behave as normal
and the result of bar will be returned from the bond/with-trap form. If
foo is called, then bond/with-trap will throw an exception.
