### PR TITLE
Improve the build setup - add code coverage test reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Bond provides one main macro, with-spy. It takes a vector of defn vars (vars tha
 
 Bond also provides with-stub. It works the same as with-spy, but redefines the fn to return (constantly nil), while also spying on it.
 
+
+Code Coverage
+-------------
+![codecov.io](https://codecov.io/github/circleci/bond/branch.svg?branch=master)
+
 License
 -------
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,8 @@
 machine:
+  environment:
+    CLOVERAGE_VERSION: 1.0.7-SNAPSHOT
+  python:
+    version: 3.5.0
   java:
     version: oraclejdk8
 general:
@@ -9,4 +13,6 @@ test:
     - mkdir $CIRCLE_TEST_REPORTS/lein
   override:
     - lein test-out junit $CIRCLE_TEST_REPORTS/lein/results.xml
-    - lein cloverage
+    - lein cloverage --codecov
+  post:
+    - codecov --token=$CODECOV_TOKEN --file target/coverage/codecov.json

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,12 @@
+machine:
+  java:
+    version: oraclejdk8
+general:
+  artifacts:
+    - target/coverage
+test:
+  pre:
+    - mkdir $CIRCLE_TEST_REPORTS/lein
+  override:
+    - lein test-out junit $CIRCLE_TEST_REPORTS/lein/results.xml
+    - lein cloverage

--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]]
-  :plugins [[lein-cloverage "1.0.6"]
+  :plugins [[lein-cloverage "1.0.7-SNAPSHOT"]
             [lein-test-out "0.3.1" :exclusions [org.clojure/clojure]]])

--- a/project.clj
+++ b/project.clj
@@ -2,4 +2,6 @@
   :description "Spying library for testing"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]])
+  :dependencies [[org.clojure/clojure "1.7.0"]]
+  :plugins [[lein-cloverage "1.0.6"]
+            [lein-test-out "0.3.1" :exclusions [org.clojure/clojure]]])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+codecov

--- a/test/bond/test/james.clj
+++ b/test/bond/test/james.clj
@@ -7,11 +7,15 @@
 
 (defn bar [x] (println "bar!") (* 2 x))
 
-(deftest spy-works []
+(deftest spy-logs-args-and-results []
   (bond/with-spy [foo]
     (foo 1)
     (foo 2)
-    (is (= 2 (-> foo bond/calls count)))))
+    (let [exception (is (thrown? clojure.lang.ArityException (foo 3 4)))]
+      (is (= [{:args [1] :return 2}
+              {:args [2] :return 4}
+              {:args [3 4] :throw exception}]
+             (bond/calls foo))))))
 
 (deftest stub-works []
   (is (= ""


### PR DESCRIPTION
- Specify the version of Java that should be used for testing
- Upgrade Clojure dep to 1.7
- Add cloverage for code coverage data
- Add test result XML output