### PR TITLE
fixed a cljs compilation error

### DIFF
--- a/src/bond/james.cljc
+++ b/src/bond/james.cljc
@@ -11,7 +11,7 @@
                      (swap! calls conj {:args args
                                         :return resp})
                      resp)
-                   (catch Exception e
+                   (catch #?(:clj Exception :cljs js/Error) e
                      (swap! calls conj {:args args
                                         :throw e})
                      (throw e))))


### PR DESCRIPTION
`Exception` is not valid cljs, but `js/Error` is. added a conditional to catch the correct exception in the correct enviornment