### PR TITLE
Add support for stubbing consecutive calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Bond also provides with-stub. It works the same as with-spy, but redefines the f
   (with-stub [[foo (fn [x] "foo")]
               [bar (fn [y] "bar")]]
     (is (= ["foo" "bar"] [(foo 1) (bar 2)]))))
+    
+(deftest consecutive-stubbing
+  (with-stub [[foo [(fn [x] "foo1") 
+                    (fn [x] "foo2") 
+                    (fn [x] "foo3")]]
+              [bar (fn [y] "bar")]]
+    (is (= ["foo1" "foo2" "foo3" "bar"] [(foo 1) (foo 1) (foo 1) (bar 2)]))))
+    
 ```
 
 License

--- a/src/bond/james.cljc
+++ b/src/bond/james.cljc
@@ -3,11 +3,11 @@
 (defn spy
   "wrap f, returning a new fn that keeping track of its call count and arguments"
   [f]
-  (let [calls (atom [])
-        old-f f]
+  (let [calls (atom [])]
     (with-meta (fn [& args]
                  (try
-                   (let [resp (apply old-f args)]
+                   (let [old-f (if (vector? f) (nth f (count @calls)) f)
+                         resp (apply old-f args)]
                      (swap! calls conj {:args args
                                         :return resp})
                      resp)

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -35,3 +35,20 @@
     (testing "spying works"
       (is (= [4] (-> foo bond/calls first :args)))
       (is (= [3] (-> bar bond/calls first :args))))))
+
+
+(deftest iterator-style-stubbing-works []
+  (bond/with-stub [foo
+                   [bar [#(str "first arg is " %)
+                         #(str "second arg is " %)
+                         #(str "third arg is " %)]]]
+    (testing "stubbing works"
+      (is (nil? (foo 4)))
+      (is (= "first arg is 3" (bar 3)))
+      (is (= "second arg is 4" (bar 4)))
+      (is (= "third arg is 5" (bar 5))))
+    (testing "spying works"
+      (is (= [4] (-> foo bond/calls first :args)))
+      (is (= [3] (-> bar bond/calls first :args)))
+      (is (= [4] (-> bar bond/calls second :args)))
+      (is (= [5] (-> bar bond/calls last :args))))))


### PR DESCRIPTION
Sometimes we need to stub with different return value/exception for the same method call. Typical use case could be mocking iterators. Another use case that I faced is testing retries. 
For example, we are testing a function which makes a network call and on exception, retries once. For testing, we need to mock the network call with two possible outcomes: first it should throw an exception, next time, it should return expected result.