### PR TITLE
Allow spying and stubbing entire namespaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ Bond also provides with-stub. It works the same as with-spy, but redefines the f
     
 ```
 
+In addition to `with-spy` and `with-stub`, Bond also provides `with-spy-ns`
+and `with-stub-ns` which can spy/stub every function in a namespace in one go:
+
+```clojure
+(ns test.foo
+  (:require [bond.james :as bond]
+            [clojure.test :refer (deftest is)]))
+
+(defn foo [] :foo)
+
+(defn bar [] :bar)
+
+(deftest you-can-stub-entire-ns
+  (is (= :foo (foo)))
+  (is (= :bar (bar)))
+  (bond/with-stub-ns [[foo (constantly :baz)]]
+    (is (= :baz (foo)))
+    (is (= :baz (bar)))))
+```
+
 License
 -------
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject circleci/bond "0.2.10"
+(defproject circleci/bond "0.2.11"
   :description "Spying library for testing"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -52,3 +52,22 @@
       (is (= [3] (-> bar bond/calls first :args)))
       (is (= [4] (-> bar bond/calls second :args)))
       (is (= [5] (-> bar bond/calls last :args))))))
+
+(deftest spying-entire-namespaces-works
+  (bond/with-spy-ns [bond.test.james]
+    (foo 1)
+    (foo 2)
+    (is (= [{:args [1] :return 2}
+            {:args [2] :return 4}]
+           (bond/calls foo)))
+    (is (= 0 (-> bar bond/calls count)))))
+
+(deftest stubbing-entire-namespaces-works
+  (testing "without replacements"
+    (bond/with-stub-ns [bond.test.james]
+      (is (nil? (foo 10)))
+      (is (= [10] (-> foo bond/calls first :args)))))
+  (testing "with replacements"
+    (bond/with-stub-ns [[bond.test.james (constantly 3)]]
+      (is (= 3 (foo 10)))
+      (is (= [10] (-> foo bond/calls first :args))))))


### PR DESCRIPTION
Add `with-spy-namespaces` and `with-stub-namespaces` which will spy/stub every function in the namespaces passed to them. This can be useful for establishing boundaries in tests.