### PR TITLE
move clj and cljs dependencies into dev profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,17 @@
-(defproject circleci/bond "0.2.10"
+(defproject circleci/bond "0.2.11"
   :description "Spying library for testing"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.228"]
-                 [com.cemerick/clojurescript.test "0.3.0"]]
+
   :plugins [[lein-test-out "0.3.1" :exclusions [org.clojure/clojure]]
             [lein-cljsbuild "1.1.3"]]
+
+  :profiles {:dev {:dependencies
+                   [[org.clojure/test.check "0.9.0"]
+                    [org.clojure/clojure "1.7.0"]
+                    [org.clojure/clojurescript "1.7.228"]
+                    [com.cemerick/clojurescript.test "0.3.0"]]}}
+
   :cljsbuild {:builds [{:source-paths ["src" "test"]
                         :compiler {:output-dir "resources/public/js/out"
                                    :output-to "resources/public/js/test-bond.js"


### PR DESCRIPTION
Moving dependencies into `:dev` profile so that they don't get bundled into the library.