### PR TITLE
Fix with-spy-ns and with-stub-ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Bond is a spying and stubbing library, primarily intended for tests.
 
 ```clojure
 
-[circleci/bond "0.2.9"]
+[circleci/bond "0.2.12"]
 ```
 
 ```clojure

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject circleci/bond "0.2.11"
+(defproject circleci/bond "0.2.12"
   :description "Spying library for testing"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -1,73 +1,69 @@
 (ns bond.test.james
   (:require #?(:clj [clojure.test :refer (deftest is testing)])
-            [bond.james :as bond :include-macros true])
+            [bond.james :as bond :include-macros true]
+            [bond.test.target :as target])
   #?(:cljs (:require-macros [cljs.test :refer (is deftest testing)])))
 
-
-(defn foo [x] (* 2 x))
-
-(defn bar [x] (println "bar!") (* 2 x))
-
 (deftest spy-logs-args-and-results []
-  (bond/with-spy [foo]
-    (foo 1)
-    (foo 2)
+  (bond/with-spy [target/foo]
+    (target/foo 1)
+    (target/foo 2)
     (is (= [{:args [1] :return 2}
             {:args [2] :return 4}]
-           (bond/calls foo)))
+           (bond/calls target/foo)))
     ;; cljs doesn't throw artity exceptions
-    #?(:clj (let [exception (is (thrown? clojure.lang.ArityException (foo 3 4)))]
+    #?(:clj (let [exception (is (thrown? clojure.lang.ArityException (target/foo 3 4)))]
               (is (= {:args [3 4] :throw exception}
-                     (-> foo bond/calls last)))))))
+                     (-> target/foo bond/calls last)))))))
 
 (deftest stub-works []
   (is (= ""
          (with-out-str
-           (bond/with-stub [bar]
-             (bar 3))))))
+           (bond/with-stub [target/bar]
+             (target/bar 3))))))
 
 (deftest stub-with-replacement-works []
-  (bond/with-stub [foo
-                   [bar #(str "arg is " %)]]
+  (bond/with-stub [target/foo
+                   [target/bar #(str "arg is " %)]]
     (testing "stubbing works"
-      (is (nil? (foo 4)))
-      (is (= "arg is 3" (bar 3))))
+      (is (nil? (target/foo 4)))
+      (is (= "arg is 3" (target/bar 3))))
     (testing "spying works"
-      (is (= [4] (-> foo bond/calls first :args)))
-      (is (= [3] (-> bar bond/calls first :args))))))
+      (is (= [4] (-> target/foo bond/calls first :args)))
+      (is (= [3] (-> target/bar bond/calls first :args))))))
 
 
 (deftest iterator-style-stubbing-works []
-  (bond/with-stub [foo
-                   [bar [#(str "first arg is " %)
-                         #(str "second arg is " %)
-                         #(str "third arg is " %)]]]
+  (bond/with-stub [target/foo
+                   [target/bar [#(str "first arg is " %)
+                                #(str "second arg is " %)
+                                #(str "third arg is " %)]]]
     (testing "stubbing works"
-      (is (nil? (foo 4)))
-      (is (= "first arg is 3" (bar 3)))
-      (is (= "second arg is 4" (bar 4)))
-      (is (= "third arg is 5" (bar 5))))
+      (is (nil? (target/foo 4)))
+      (is (= "first arg is 3" (target/bar 3)))
+      (is (= "second arg is 4" (target/bar 4)))
+      (is (= "third arg is 5" (target/bar 5))))
     (testing "spying works"
-      (is (= [4] (-> foo bond/calls first :args)))
-      (is (= [3] (-> bar bond/calls first :args)))
-      (is (= [4] (-> bar bond/calls second :args)))
-      (is (= [5] (-> bar bond/calls last :args))))))
+      (is (= [4] (-> target/foo bond/calls first :args)))
+      (is (= [3] (-> target/bar bond/calls first :args)))
+      (is (= [4] (-> target/bar bond/calls second :args)))
+      (is (= [5] (-> target/bar bond/calls last :args))))))
 
 (deftest spying-entire-namespaces-works
-  (bond/with-spy-ns [bond.test.james]
-    (foo 1)
-    (foo 2)
+  (bond/with-spy-ns [bond.test.target]
+    (target/foo 1)
+    (target/foo 2)
     (is (= [{:args [1] :return 2}
             {:args [2] :return 4}]
-           (bond/calls foo)))
-    (is (= 0 (-> bar bond/calls count)))))
+           (bond/calls target/foo)))
+    (is (= 0 (-> target/bar bond/calls count)))))
 
 (deftest stubbing-entire-namespaces-works
   (testing "without replacements"
-    (bond/with-stub-ns [bond.test.james]
-      (is (nil? (foo 10)))
-      (is (= [10] (-> foo bond/calls first :args)))))
+    (bond/with-stub-ns [bond.test.target]
+      (is (nil? (target/foo 10)))
+      (is (= [10] (-> target/foo bond/calls first :args)))))
   (testing "with replacements"
-    (bond/with-stub-ns [[bond.test.james (constantly 3)]]
-      (is (= 3 (foo 10)))
-      (is (= [10] (-> foo bond/calls first :args))))))
+    (bond/with-stub-ns [[bond.test.target (constantly 3)]]
+      (is (= 3 (target/foo 10)))
+      (is (= [10] (-> target/foo bond/calls first :args))))))

--- a/test/bond/test/target.cljc
+++ b/test/bond/test/target.cljc
@@ -1,0 +1,13 @@
+(ns bond.test.target)
+
+(defn foo
+  [x]
+  (* 2 x))
+
+(defn bar
+  [x]
+  (println "bar!") (* 2 x))
+
+(defmacro baz
+  [x]
+  `(* ~x 2))


### PR DESCRIPTION
They couldn't stub/spy across namespaces because the previous implementation didn't fully qualify the redef'ed symbols.