### PR TITLE
Better support for stubbing private fns

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ Bond also provides `with-stub!`. It works the same as `with-spy`, but redefines 
     
 ```
 
+Private functions can also be stubbed or spyed:
+
+``` clojure
+(ns test.foo)
+
+(defn- foo [x] ...)
+```
+
+``` clojure
+(ns test.bar
+  (:require [bond.james :as bond :refer [with-stub!]]
+            [test.foo :as foo]))
+
+(deftest foo-is-called
+  (with-stub! [[foo/foo (fn [x] "foo")]]
+    (is (= "foo" (#'foo/foo 1)))
+    (is (= [1] (-> #'foo/foo bond/calls first :args)))))
+```
+
 There is also a `with-stub` macro which works like `with-stub!` but omits the argument check.
 
 In addition to `with-spy` and `with-stub!`, Bond also provides `with-spy-ns`

--- a/src/bond/james.cljc
+++ b/src/bond/james.cljc
@@ -22,7 +22,10 @@
   of maps, one per call. Each map contains the keys :args and :return
   or :throw"
   [f]
-  (-> f (meta) ::calls (deref)))
+  (some-> (if (var? f) @f f)
+          meta
+          ::calls
+          deref))
 
 (defn ns->fn-symbols
   "A utility function to get a sequence of fully-qualified symbols for all the

--- a/src/bond/james.cljc
+++ b/src/bond/james.cljc
@@ -43,7 +43,7 @@
   fn to track call counts, but does not change the fn's behavior"
   [vs & body]
   `(with-redefs ~(->> (mapcat (fn [v]
-                                [v `(spy ~v)]) vs)
+                                [v `(spy (deref ~(list 'var v)))]) vs)
                       (vec))
      (do ~@body)))
 

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -23,9 +23,14 @@
              (target/bar 3))))))
 
 (deftest stub-works-with-private-fn
-  (bond/with-stub [[target/private-foo (fn [x] (* x x))]]
-    (is (= 9 (#'target/private-foo 3)))
-    (is (= [3] (-> #'target/private-foo bond/calls first :args)))))
+  (testing "without replacement"
+    (bond/with-stub [target/private-foo]
+      (is (nil? (#'target/private-foo 3)))
+      (is (= [3] (-> #'target/private-foo bond/calls first :args)))))
+  (testing "with replacement"
+    (bond/with-stub [[target/private-foo (fn [x] (* x x))]]
+      (is (= 9 (#'target/private-foo 3)))
+      (is (= [3] (-> #'target/private-foo bond/calls first :args))))))
 
 (deftest stub-with-replacement-works
   (bond/with-stub [target/foo

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -16,13 +16,13 @@
               (is (= {:args [3 4] :throw exception}
                      (-> target/foo bond/calls last)))))))
 
-(deftest stub-works []
+(deftest stub-works
   (is (= ""
          (with-out-str
            (bond/with-stub [target/bar]
              (target/bar 3))))))
 
-(deftest stub-works-with-priviate-fn []
+(deftest stub-works-with-private-fn
   (bond/with-stub [[target/private-foo (fn [x] (* x x))]]
     (is (= 9 (#'target/private-foo 3)))
     (is (= [3] (-> #'target/private-foo bond/calls first :args)))))

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -22,6 +22,11 @@
            (bond/with-stub [target/bar]
              (target/bar 3))))))
 
+(deftest stub-works-with-priviate-fn []
+  (bond/with-stub [[target/private-foo (fn [x] (* x x))]]
+    (is (= 9 (#'target/private-foo 3)))
+    (is (= [3] (-> #'target/private-foo bond/calls first :args)))))
+
 (deftest stub-with-replacement-works
   (bond/with-stub [target/foo
                    [target/bar #(str "arg is " %)]]

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -6,8 +6,8 @@
 
 (deftest spy-logs-args-and-results
   (bond/with-spy [target/foo]
-    (target/foo 1)
-    (target/foo 2)
+    (is (= 2 (target/foo 1)))
+    (is (= 4 (target/foo 2)))
     (is (= [{:args [1] :return 2}
             {:args [2] :return 4}]
            (bond/calls target/foo)))
@@ -15,6 +15,14 @@
     #?(:clj (let [exception (is (thrown? clojure.lang.ArityException (target/foo 3 4)))]
               (is (= {:args [3 4] :throw exception}
                      (-> target/foo bond/calls last)))))))
+
+(deftest spy-can-spy-private-fns
+  (bond/with-spy [target/private-foo]
+    (is (= 4 (#'target/private-foo 2)))
+    (is (= 6 (#'target/private-foo 3)))
+    (is (= [{:args [2] :return 4}
+            {:args [3] :return 6}]
+           (bond/calls #'target/private-foo)))))
 
 (deftest stub-works
   (is (= ""

--- a/test/bond/test/target.cljc
+++ b/test/bond/test/target.cljc
@@ -4,6 +4,10 @@
   [x]
   (* 2 x))
 
+(defn- private-foo
+  [x]
+  (* 2 x))
+
 (defn bar
   [x]
   (println "bar!") (* 2 x))


### PR DESCRIPTION
Some people have a problem using bond for private functions because of pretty cryptic syntax, this PR adds a bit better support.
Before private fn stubbing/checking looked like:
```clojure
(deftest foo-is-called
+  (with-stub! [[foo/foo (fn [x] "foo")]]
+    (is (= "foo" (#'foo/foo 1)))
+    (is (= [1] (-> @#'foo/foo bond/calls first :args)))))
```
Notice the difference in calling private function and checking stub args. Now it'll be possible to have the same (`#'foo/foo`) syntax for both.