### PR TITLE
Drop runtime dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,7 @@
   :description "Spying library for testing"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.228"]]
+  :dependencies []
   :plugins [[lein-test-out "0.3.1" :exclusions [org.clojure/clojure]]
             [lein-cljsbuild "1.1.3"]
             [lein-cloverage "1.0.9"]]
@@ -15,4 +14,6 @@
               :test-commands {"unit" ["node_modules/phantomjs-prebuilt/bin/phantomjs"
                                       "resources/test/phantom/runner.js"
                                       "resources/test/test.html"]}}
-  :profiles {:dev {:dependencies [[com.cemerick/clojurescript.test "0.3.0"]]}})
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
+                                  [org.clojure/clojurescript "1.7.228"]
+                                  [com.cemerick/clojurescript.test "0.3.0"]]}})


### PR DESCRIPTION
Bond only needs Clojure and CLJS dependencies for its own build/tests.
Any consumer of bond will already have a Clojure or CLJS dependency,
don't force them to exclude dependencies from bond itself.