### PR TITLE
Grab arglists meta outside of with-redefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,13 @@ Private functions can also be stubbed or spyed:
     (is (= [1] (-> #'foo/foo bond/calls first :args)))))
 ```
 
-There is also a `with-stub` macro which works like `with-stub!` but omits the argument check.
+Stubbing multimethods with `with-stub!` can be done by setting the `:arglists` metadata on the var:
+
+```clojure
+(defmulti ^{:arglists '([x y z])} my-multi (fn [x y z] x))
+```
+
+Unfortunately, since setting `:arglists` metadata on vars in ClojureScript is unsupported (as of `1.9.946`), multimethods can only be stubbed using the `with-stub` macro which works like `with-stub!` but omits the argument check.
 
 In addition to `with-spy` and `with-stub!`, Bond also provides `with-spy-ns`
 and `with-stub-ns` which can spy/stub every function in a namespace in one go:

--- a/src/bond/james.cljc
+++ b/src/bond/james.cljc
@@ -78,10 +78,11 @@
 (defn- args-match? [arg-count arglists]
   (some (partial arglist-match? arg-count) arglists))
 
-(defn stub! [v replacement]
+(defn stub!
+  [v replacement arglists]
   (let [f (spy replacement)]
     (with-meta (fn [& args]
-                 (if (args-match? (count args) (:arglists (meta v)))
+                 (if (args-match? (count args) arglists)
                    (apply f args)
                    (throw (new #?(:clj clojure.lang.ArityException :cljs js/Error)
                                (count args) (str (:ns (meta v)) "/"
@@ -91,13 +92,30 @@
 (defmacro with-stub!
   "Like with-stub, but throws an exception upon arity mismatch."
   [vs & body]
-  `(with-redefs ~(->> (mapcat (fn [v]
-                                (if (vector? v)
-                                  [(first v) `(stub! (var ~(first v))
-                                                     ~(second v))]
-                                  [v `(stub! (var ~v) (constantly nil))])) vs)
-                      (vec))
-     ~@body))
+  (let [syms (map (fn [v]
+                    (if (vector? v)
+                      (first v)
+                      v))
+                  vs)
+        symbol-forms (map (fn [sym]
+                            `(quote ~sym))
+                          syms)
+        arglists (map (fn [sym]
+                        `(:arglists (meta (var ~sym))))
+                      syms)
+        arglists-map-sym (gensym "arglists-map")]
+    `(let [~arglists-map-sym ~(zipmap symbol-forms arglists)]
+       (with-redefs ~(->> (mapcat (fn [v]
+                                    (if (vector? v)
+                                      [(first v) `(stub! (var ~(first v))
+                                                         ~(second v)
+                                                         (get ~arglists-map-sym (quote ~(first v))))]
+                                      [v `(stub! (var ~v)
+                                                 (constantly nil)
+                                                 (get ~arglists-map-sym (quote ~v)))]))
+                                  vs)
+                          (vec))
+        ~@body))))
 
 (defmacro with-stub-ns
   "Takes a vector of namespaces and/or [namespace replacement] vectors.

--- a/src/bond/james.cljc
+++ b/src/bond/james.cljc
@@ -79,15 +79,17 @@
   (some (partial arglist-match? arg-count) arglists))
 
 (defn stub!
-  [v replacement arglists]
-  (let [f (spy replacement)]
-    (with-meta (fn [& args]
-                 (if (args-match? (count args) arglists)
-                   (apply f args)
-                   (throw (new #?(:clj clojure.lang.ArityException :cljs js/Error)
-                               (count args) (str (:ns (meta v)) "/"
-                                                 (:name (meta v)))))))
-      (meta f))))
+  ([v replacement]
+   (stub! v replacement (:arglists (meta v))))
+  ([v replacement arglists]
+   (let [f (spy replacement)]
+     (with-meta (fn [& args]
+                  (if (args-match? (count args) arglists)
+                    (apply f args)
+                    (throw (new #?(:clj clojure.lang.ArityException :cljs js/Error)
+                                (count args) (str (:ns (meta v)) "/"
+                                                  (:name (meta v)))))))
+       (meta f)))))
 
 (defmacro with-stub!
   "Like with-stub, but throws an exception upon arity mismatch."

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -80,36 +80,33 @@
                  (target/quuk 1)))
     (is (= [6 5] (target/quux 8 7 6 5)))))
 
-(defn two-arg-fn [arg1 arg2] nil)
-
-(defmulti some-multimethod {:arglists '([arg1 arg2 arg3])} :dispatch-fn)
+#?(:clj (defmulti ^{:arglists '([arg1 arg2])} two-arg-fn :dispatch-fn)
+   ;; setting :arglists metadata in cljs does not work
+   :cljs (defn two-arg-fn [arg1 arg2] nil))
 
 (deftest stub!-works
   (testing "2 arity"
     (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
                  ((bond/stub! #'two-arg-fn (fn [arg1] nil)) :foo)))
-    (is (= [:arg1 :arg2 :arg3]
-           ((bond/stub! #'some-multimethod
-                        (fn [arg1 arg2 arg3]
-                          [arg1 arg2 arg3]))
+    (is (= [:arg1 :arg2]
+           ((bond/stub! #'two-arg-fn
+                        (fn [arg1 arg2]
+                          [arg1 arg2]))
             :arg1
-            :arg2
-            :arg3))))
+            :arg2))))
   (testing "3 arity"
     (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
-                 ((bond/stub! #'some-multimethod
-                              (fn [arg1 arg2])
-                              '([arg1 arg2 arg3]))
-                  :arg1
-                  :arg2)))
-    (is (= [:arg1 :arg2 :arg3]
-           ((bond/stub! #'some-multimethod
-                        (fn [arg1 arg2 arg3]
-                          [arg1 arg2 arg3])
-                        '([arg1 arg2 arg3]))
+                 ((bond/stub! #'two-arg-fn
+                              (fn [arg1])
+                              '([arg1 arg2]))
+                  :arg1)))
+    (is (= [:arg1 :arg2]
+           ((bond/stub! #'two-arg-fn
+                        (fn [arg1 arg2]
+                          [arg1 arg2])
+                        '([arg1 arg2]))
             :arg1
-            :arg2
-            :arg3)))))
+            :arg2)))))
 
 (deftest spying-entire-namespaces-works
   (bond/with-spy-ns [bond.test.target]

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -87,10 +87,29 @@
 (deftest stub!-works
   (testing "2 arity"
     (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
-                 ((bond/stub! #'two-arg-fn (fn [arg1] nil)) :foo))))
+                 ((bond/stub! #'two-arg-fn (fn [arg1] nil)) :foo)))
+    (is (= [:arg1 :arg2 :arg3]
+           ((bond/stub! #'some-multimethod
+                        (fn [arg1 arg2 arg3]
+                          [arg1 arg2 arg3]))
+            :arg1
+            :arg2
+            :arg3))))
   (testing "3 arity"
     (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
-                 ((bond/stub! #'some-multimethod (fn [arg1 arg2])) :arg1 :arg2)))))
+                 ((bond/stub! #'some-multimethod
+                              (fn [arg1 arg2])
+                              '([arg1 arg2 arg3]))
+                  :arg1
+                  :arg2)))
+    (is (= [:arg1 :arg2 :arg3]
+           ((bond/stub! #'some-multimethod
+                        (fn [arg1 arg2 arg3]
+                          [arg1 arg2 arg3])
+                        '([arg1 arg2 arg3]))
+            :arg1
+            :arg2
+            :arg3)))))
 
 (deftest spying-entire-namespaces-works
   (bond/with-spy-ns [bond.test.target]

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -80,6 +80,18 @@
                  (target/quuk 1)))
     (is (= [6 5] (target/quux 8 7 6 5)))))
 
+(defn two-arg-fn [arg1 arg2] nil)
+
+(defmulti some-multimethod {:arglists '([arg1 arg2 arg3])} :dispatch-fn)
+
+(deftest stub!-works
+  (testing "2 arity"
+    (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
+                 ((bond/stub! #'two-arg-fn (fn [arg1] nil)) :foo))))
+  (testing "3 arity"
+    (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
+                 ((bond/stub! #'some-multimethod (fn [arg1 arg2])) :arg1 :arg2)))))
+
 (deftest spying-entire-namespaces-works
   (bond/with-spy-ns [bond.test.target]
     (target/foo 1)


### PR DESCRIPTION
Arity checking in `bond/with-stub!` does not work with multimethods. We attempted to work around this by adding `:arglists` metadata our var. In some cases (unable to consistently reproduce), `with-redefs` will lose the original var's metadata.

This change makes it so that the original var's arglists are computed outside of the `with-redefs` and passed to the stub.