### PR TITLE
Useful error message for when stub!/with-stub! will fail

### DIFF
--- a/src/bond/james.cljc
+++ b/src/bond/james.cljc
@@ -79,6 +79,9 @@
   (some (partial arglist-match? arg-count) arglists))
 
 (defn stub! [v replacement]
+  (when (empty? (:arglists (meta v)))
+    (throw (new #?(:clj IllegalArgumentException :cljs js/Error)
+                "stub!/with-stub! may only be used on functions which include :arglists in their metadata. Use stub/with-stub instead.")))
   (let [f (spy replacement)]
     (with-meta (fn [& args]
                  (if (args-match? (count args) (:arglists (meta v)))

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -67,6 +67,11 @@
       (is (= [4] (-> target/bar bond/calls second :args)))
       (is (= [5] (-> target/bar bond/calls last :args))))))
 
+(deftest stub!-complains-loudly-if-there-is-no-arglists
+  (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
+               (bond/with-stub! [[target/without-arglists (constantly 42)]]
+                 (is false)))))
+
 (deftest stub!-throws-arity-exception
   (bond/with-stub! [[target/foo (constantly 9)]]
     (is (= 9 (target/foo 12)))

--- a/test/bond/test/target.cljc
+++ b/test/bond/test/target.cljc
@@ -23,3 +23,7 @@
 (defmacro baz
   [x]
   `(* ~x 2))
+
+(def without-arglists
+  (fn [x]
+    (* 2 x)))


### PR DESCRIPTION
If a function was generated without `:arglists` metadata then it can't be stubbed using `with-stub!` since `stub!` can't verify the arity of the replacement function.

Instead of giving an inscrutable error message, we now assert that `:arglists` exists and produce an error message which points the user in the right direction.

Fixes: #41