### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject circleci/bond "0.3.1"
+(defproject circleci/bond "0.3.2"
   :description "Spying library for testing"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}


### PR DESCRIPTION
Differences from 0.3.1 -> 0.3.2:

- `with-stub!` now produces more useful errors when attempting to stub function with no `:arglists` in their metadata. (#43)
- Updates to the README (#40, #42)