### PR TITLE
Thread-local variants of spy and stub

### DIFF
--- a/src/bond/james.cljc
+++ b/src/bond/james.cljc
@@ -1,5 +1,8 @@
 (ns bond.james)
 
+(def ^:dynamic local-redefinitions {})
+(def ^:dynamic call-tracker nil)
+
 (defn spy
   "wrap f, returning a new fn that keeping track of its call count and arguments"
   [f]
@@ -115,3 +118,177 @@
                            (ns->fn-symbols n)))
                        namespaces)
      (do ~@body)))
+
+(defn current->original-definition
+  [v]
+  (when (var? v)
+    (get (meta v) :original)))
+
+(defn redef-binding->originals
+  [x]
+  (if (vector? x)
+    `(current->original-definition (var ~(first x)))
+    `(current->original-definition (var ~x))))
+
+(defn redefiniton-fn
+  [a-var]
+  (fn [& args]
+    (let [original-f (current->original-definition a-var)
+          current-f (get local-redefinitions
+                         a-var
+                         original-f)]
+      (try
+        (let [result (apply current-f args)]
+          (when (and (thread-bound? #'call-tracker)
+                     (vector? (get @call-tracker original-f)))
+            (swap! call-tracker
+                   update
+                   original-f
+                   (fnil conj [])
+                   {:args args
+                    :return result}))
+          result)
+        (catch #?(:clj Exception :cljs js/Error) e
+          (when (and (thread-bound? #'call-tracker)
+                     (vector? (get @call-tracker original-f)))
+            (swap! call-tracker
+                   update
+                   original-f
+                   (fnil conj [])
+                   {:args args
+                    :throw e}))
+          (throw e))))))
+
+(defn dynamic-redefs
+  [vars func]
+  (let [un-redefs (remove #(:already-bound? (meta %)) vars)]
+    (doseq [a-var un-redefs]
+      (locking a-var
+        (when-not (:already-bound? (meta a-var))
+          (let [old-val (.getRawRoot ^clojure.lang.Var a-var)
+                metadata {:already-bound? true
+                          :original old-val}]
+            (.bindRoot ^clojure.lang.Var a-var
+                       (with-meta (redefiniton-fn a-var) metadata))
+            (alter-meta! a-var
+                         (fn [m]
+                           (merge m metadata))))))))
+  (func))
+
+(defn xs->map
+  [xs]
+  (persistent!
+   (reduce (fn [acc [k v]] (assoc! acc `(var ~k) v))
+           (transient {})
+           (partition 2 xs))))
+
+(defmacro with-dynamic-redefs
+  [bindings & body]
+  (let [map-bindings (xs->map bindings)]
+    `(let [old-rebindings# local-redefinitions]
+       (binding [local-redefinitions (merge old-rebindings# ~map-bindings)]
+         (dynamic-redefs ~(vec (keys map-bindings))
+                         (fn [] ~@body))))))
+
+(defn local-spy
+  "Same as spy, but does it on the current clojure thread"
+  [v f]
+  (let [number-of-calls (atom 0)]
+    (fn [& args]
+      (let [spied-f (cond (nil? f) (current->original-definition v)
+                          (vector? f) (nth f @number-of-calls)
+                          :else f)]
+        (try (apply spied-f args)
+             (finally (swap! number-of-calls inc)))))))
+
+(defn local-calls
+  "Same as calls, but for those symbols which were locally spied or
+  stubbed."
+  [f]
+  (let [me (if (var? f) @f f)]
+    (if (thread-bound? #'call-tracker)
+      (get @call-tracker (:original (meta me)) [])
+      [])))
+
+(defmacro with-local-spy
+  "Same as with-spy but spies only on the current clojure thread."
+  [vs & body]
+  `(let [current-call-tracker# (when (thread-bound? #'call-tracker)
+                                (deref call-tracker))]
+     (with-dynamic-redefs ~(->> (mapcat (fn [v]
+                                          [v `(local-spy ~(list 'var v)
+                                                         (local-redefinitions
+                                                          ~(list 'var v)))])
+                                        vs)
+                                (vec))
+       (binding [call-tracker (if current-call-tracker#
+                               (do (swap! call-tracker
+                                          merge
+                                          ~(zipmap (map redef-binding->originals vs)
+                                                   (repeat [])))
+                                   call-tracker)
+                               (atom ~(zipmap (map redef-binding->originals vs)
+                                              (repeat []))))]
+         ~@body))))
+
+(defmacro with-local-spy-ns
+  "Same as with-spy but does it on the current clojure thread."
+  [namespaces & body]
+  `(with-local-spy ~(mapcat ns->fn-symbols namespaces)
+     (do ~@body)))
+
+(defmacro with-local-stub
+  "Same as with-stub but only stubs it on the local clojure thread."
+  [vs & body]
+  `(let [current-call-tracker# (when (thread-bound? #'call-tracker)
+                                (deref call-tracker))]
+     (with-dynamic-redefs ~(->> (mapcat (fn [v]
+                                          (if (vector? v)
+                                            [(first v) `(local-spy ~(list 'var (first v)) ~(second v))]
+                                            [v `(local-spy ~(list 'var v) (constantly nil))])) vs)
+                                (vec))
+       (binding [call-tracker (if current-call-tracker#
+                               (do (swap! call-tracker
+                                          merge
+                                          ~(zipmap (map redef-binding->originals vs)
+                                                   (repeat [])))
+                                   call-tracker)
+                               (atom ~(zipmap (map redef-binding->originals vs)
+                                              (repeat []))))]
+         ~@body))))
+
+(defn local-stub! [v replacement]
+  (when (empty? (:arglists (meta v)))
+    (throw (new #?(:clj IllegalArgumentException :cljs js/Error)
+                "stub!/with-stub! may only be used on functions which include :arglists in their metadata. Use stub/with-stub instead.")))
+  (let [f (local-spy v replacement)]
+    (with-meta (fn [& args]
+                 (if (args-match? (count args) (:arglists (meta v)))
+                   (apply f args)
+                   (throw (new #?(:clj clojure.lang.ArityException :cljs js/Error)
+                               (count args) (str (:ns (meta v)) "/"
+                                                 (:name (meta v)))))))
+      (meta f))))
+
+(defmacro with-local-stub!
+  "Like with-stub!, but only works for thread-locally"
+  [vs & body]
+  `(let [current-call-tracker# (when (thread-bound? #'call-tracker)
+                                 (deref call-tracker))]
+     (with-dynamic-redefs ~(->> (mapcat (fn [v]
+                                          (if (vector? v)
+                                            [(first v) `(local-stub! (var ~(first v))
+                                                                     ~(second v))]
+                                            [v `(local-stub! (var ~v) (constantly nil))]))
+                                        vs)
+                                (vec))
+       (binding [call-tracker (if current-call-tracker#
+                                (do (swap! call-tracker
+                                           merge
+                                           ~(zipmap (map redef-binding->originals vs)
+                                                    (repeat [])))
+                                    call-tracker)
+                                (atom ~(zipmap (map redef-binding->originals vs)
+                                               (repeat []))))]
+
+         ~@body))))

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -107,66 +107,73 @@
       (is (= [10] (-> target/foo bond/calls first :args))))))
 
 (deftest local-spy-logs-args-and-results
-  (bond/with-local-spy [target/foo]
-    (is (= 2 (target/foo 1)))
-    (is (= 4 (target/foo 2)))
-    (is (= [{:args [1] :return 2}
-            {:args [2] :return 4}]
-           (bond/local-calls target/foo)))
-    ;; cljs doesn't throw ArityException
-    #?(:clj (let [exception (is (thrown? clojure.lang.ArityException (target/foo 3 4)))]
-              (is (= {:args [3 4] :throw exception}
-                     (-> target/foo bond/local-calls last)))))))
+  #?(:clj
+     (bond/with-local-spy [target/foo]
+       (is (= 2 (target/foo 1)))
+       (is (= 4 (target/foo 2)))
+       (is (= [{:args [1] :return 2}
+               {:args [2] :return 4}]
+              (bond/local-calls target/foo)))
+       ;; cljs doesn't throw ArityException
+       #?(:clj (let [exception (is (thrown? clojure.lang.ArityException (target/foo 3 4)))]
+                 (is (= {:args [3 4] :throw exception}
+                        (-> target/foo bond/local-calls last))))))))
 
 (deftest local-spy-can-spy-private-fns
-  (bond/with-local-spy [target/private-foo]
-    (is (= 4 (#'target/private-foo 2)))
-    (is (= 6 (#'target/private-foo 3)))
-    (is (= [{:args [2] :return 4}
-            {:args [3] :return 6}]
-           (bond/local-calls #'target/private-foo)))))
+  #?(:clj
+     (bond/with-local-spy [target/private-foo]
+       (is (= 4 (#'target/private-foo 2)))
+       (is (= 6 (#'target/private-foo 3)))
+       (is (= [{:args [2] :return 4}
+               {:args [3] :return 6}]
+              (bond/local-calls #'target/private-foo))))))
 
 (deftest local-stub-works
-  (is (= ""
-         (with-out-str
-           (bond/with-local-stub [target/bar]
-             (target/bar 3))))))
+  #?(:clj
+     (is (= ""
+            (with-out-str
+              (bond/with-local-stub [target/bar]
+                (target/bar 3)))))))
 
 (deftest local-stub-works-with-private-fn
-  (testing "without replacement"
-    (bond/with-local-stub [target/private-foo]
-      (is (nil? (#'target/private-foo 3)))
-      (is (= [3] (-> #'target/private-foo bond/local-calls first :args)))))
-  (testing "with replacement"
-    (bond/with-local-stub [[target/private-foo (fn [x] (* x x))]]
-      (is (= 9 (#'target/private-foo 3)))
-      (is (= [3] (-> #'target/private-foo bond/local-calls first :args))))))
+  #?(:clj
+     (do
+       (testing "without replacement"
+         (bond/with-local-stub [target/private-foo]
+           (is (nil? (#'target/private-foo 3)))
+           (is (= [3] (-> #'target/private-foo bond/local-calls first :args)))))
+       (testing "with replacement"
+         (bond/with-local-stub [[target/private-foo (fn [x] (* x x))]]
+           (is (= 9 (#'target/private-foo 3)))
+           (is (= [3] (-> #'target/private-foo bond/local-calls first :args))))))))
 
 (deftest local-stub-with-replacement-works
-  (bond/with-local-stub [target/foo
-                   [target/bar #(str "arg is " %)]]
-    (testing "stubbing works"
-      (is (nil? (target/foo 4)))
-      (is (= "arg is 3" (target/bar 3))))
-    (testing "spying works"
-      (is (= [4] (-> target/foo bond/local-calls first :args)))
-      (is (= [3] (-> target/bar bond/local-calls first :args))))))
+  #?(:clj
+     (bond/with-local-stub [target/foo
+                            [target/bar #(str "arg is " %)]]
+       (testing "stubbing works"
+         (is (nil? (target/foo 4)))
+         (is (= "arg is 3" (target/bar 3))))
+       (testing "spying works"
+         (is (= [4] (-> target/foo bond/local-calls first :args)))
+         (is (= [3] (-> target/bar bond/local-calls first :args)))))))
 
 (deftest local-iterator-style-stubbing-works
-  (bond/with-local-stub [target/foo
-                   [target/bar [#(str "first arg is " %)
-                                #(str "second arg is " %)
-                                #(str "third arg is " %)]]]
-    (testing "stubbing works"
-      (is (nil? (target/foo 4)))
-      (is (= "first arg is 3" (target/bar 3)))
-      (is (= "second arg is 4" (target/bar 4)))
-      (is (= "third arg is 5" (target/bar 5))))
-    (testing "spying works"
-      (is (= [4] (-> target/foo bond/local-calls first :args)))
-      (is (= [3] (-> target/bar bond/local-calls first :args)))
-      (is (= [4] (-> target/bar bond/local-calls second :args)))
-      (is (= [5] (-> target/bar bond/local-calls last :args))))))
+  #?(:clj
+     (bond/with-local-stub [target/foo
+                            [target/bar [#(str "first arg is " %)
+                                         #(str "second arg is " %)
+                                         #(str "third arg is " %)]]]
+       (testing "stubbing works"
+         (is (nil? (target/foo 4)))
+         (is (= "first arg is 3" (target/bar 3)))
+         (is (= "second arg is 4" (target/bar 4)))
+         (is (= "third arg is 5" (target/bar 5))))
+       (testing "spying works"
+         (is (= [4] (-> target/foo bond/local-calls first :args)))
+         (is (= [3] (-> target/bar bond/local-calls first :args)))
+         (is (= [4] (-> target/bar bond/local-calls second :args)))
+         (is (= [5] (-> target/bar bond/local-calls last :args)))))))
 
 (deftest local-stub!-complains-loudly-if-there-is-no-arglists
   (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
@@ -174,159 +181,168 @@
                  (is false)))))
 
 (deftest local-stub!-throws-arity-exception
-  (bond/with-local-stub! [[target/foo (constantly 9)]]
-    (is (= 9 (target/foo 12)))
-    (is (= [{:args [12] :return 9}] (bond/local-calls target/foo))))
-  (bond/with-local-stub! [target/bar
-                    target/quuk
-                    [target/quux (fn [_ _ & x] x)]]
-    (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
-                 (target/bar 1 2)))
-    (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
-                 (target/quuk 1)))
-    (is (= [6 5] (target/quux 8 7 6 5)))))
+  #?(:clj
+     (do (bond/with-local-stub! [[target/foo (constantly 9)]]
+           (is (= 9 (target/foo 12)))
+           (is (= [{:args [12] :return 9}] (bond/local-calls target/foo))))
+         (bond/with-local-stub! [target/bar
+                                 target/quuk
+                                 [target/quux (fn [_ _ & x] x)]]
+           (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
+                        (target/bar 1 2)))
+           (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
+                        (target/quuk 1)))
+           (is (= [6 5] (target/quux 8 7 6 5)))))))
 
 (deftest local-spying-entire-namespaces-works
-  (bond/with-local-spy-ns [bond.test.target]
-    (target/foo 1)
-    (target/foo 2)
-    (is (= [{:args [1] :return 2}
-            {:args [2] :return 4}]
-           (bond/local-calls target/foo)))
-    (is (= 0 (-> target/bar bond/local-calls count)))))
+  #?(:clj
+     (bond/with-local-spy-ns [bond.test.target]
+       (target/foo 1)
+       (target/foo 2)
+       (is (= [{:args [1] :return 2}
+               {:args [2] :return 4}]
+              (bond/local-calls target/foo)))
+       (is (= 0 (-> target/bar bond/local-calls count))))))
 
 (deftest test-with-dynamic-redefs
-  (dotimes [i 100]
-    (let [f1 (future (bond/with-dynamic-redefs [funk (constantly -100)]
-                       (Thread/sleep (rand-int 100))
-                       {:100 (funk) :t (.getName (Thread/currentThread))}))
+  #?(:clj
+     (dotimes [i 100]
+       (let [f1 (future (bond/with-dynamic-redefs [funk (constantly -100)]
+                          (Thread/sleep (rand-int 100))
+                          {:100 (funk) :t (.getName (Thread/currentThread))}))
 
-          f2 (future (bond/with-dynamic-redefs [funk (constantly -200)]
-                       (Thread/sleep (rand-int 100))
-                       {:200 (funk 9) :t (.getName (Thread/currentThread))}))
-          f3 (future (do
-                       (Thread/sleep (rand-int 100))
-                       {:orig (funk 9) :t (.getName (Thread/currentThread))}))]
-      (is (and (= (:100 @f1) -100)
-               (= (:200 @f2) -200)
-               (= (:orig @f3) {:original-args '(9)}))))))
+             f2 (future (bond/with-dynamic-redefs [funk (constantly -200)]
+                          (Thread/sleep (rand-int 100))
+                          {:200 (funk 9) :t (.getName (Thread/currentThread))}))
+             f3 (future (do
+                          (Thread/sleep (rand-int 100))
+                          {:orig (funk 9) :t (.getName (Thread/currentThread))}))]
+         (is (and (= (:100 @f1) -100)
+                  (= (:200 @f2) -200)
+                  (= (:orig @f3) {:original-args '(9)})))))))
 
 (deftest thread-safe-stub!
-  (let [p (promise)
-        f (future
-            (bond/with-local-stub! [dunk [funk (constantly -1)]]
-              (while (not (realized? p))
-                (Thread/sleep 10))
-              {:result [(funk) (dunk)]
-               :calls [(bond/local-calls funk)
-                       (bond/local-calls dunk)]}))]
-    (is (= (funk 9) {:original-args '(9)}))
-    (is (= (dunk 9) {:original-args '(9)}))
-    (deliver p true)
-    (is (= (:result @f) [-1 nil]))
-    (is (= [[{:args nil :return -1}]
-            [{:args nil :return nil}]]
-           (:calls @f)))
-    (is (= [] (bond/local-calls dunk)))
-    (is (= [] (bond/local-calls funk))))
+  #?(:clj
+     (do (let [p (promise)
+               f (future
+                   (bond/with-local-stub! [dunk [funk (constantly -1)]]
+                     (while (not (realized? p))
+                       (Thread/sleep 10))
+                     {:result [(funk) (dunk)]
+                      :calls [(bond/local-calls funk)
+                              (bond/local-calls dunk)]}))]
+           (is (= (funk 9) {:original-args '(9)}))
+           (is (= (dunk 9) {:original-args '(9)}))
+           (deliver p true)
+           (is (= (:result @f) [-1 nil]))
+           (is (= [[{:args nil :return -1}]
+                   [{:args nil :return nil}]]
+                  (:calls @f)))
+           (is (= [] (bond/local-calls dunk)))
+           (is (= [] (bond/local-calls funk))))
 
-  (let [p (promise)
-        f (future
-            (bond/with-local-stub! [[funk (constantly -1)]]
-              (while (not (realized? p))
-                (Thread/sleep 10))
-              {:result [(funk) (dunk)]
-               :calls [(bond/local-calls funk)
-                       (bond/local-calls dunk)]}))]
-    (is (= (funk 9) {:original-args '(9)}))
-    (is (= (dunk 9) {:original-args '(9)}))
-    (deliver p true)
-    (is (= (:result @f) [-1 {:original-args nil}]))
-    (is (= [[{:args nil :return -1}]
-            []]
-           (:calls @f)))
-    (is (= [] (bond/local-calls dunk)))
-    (is (= [] (bond/local-calls funk)))))
+         (let [p (promise)
+               f (future
+                   (bond/with-local-stub! [[funk (constantly -1)]]
+                     (while (not (realized? p))
+                       (Thread/sleep 10))
+                     {:result [(funk) (dunk)]
+                      :calls [(bond/local-calls funk)
+                              (bond/local-calls dunk)]}))]
+           (is (= (funk 9) {:original-args '(9)}))
+           (is (= (dunk 9) {:original-args '(9)}))
+           (deliver p true)
+           (is (= (:result @f) [-1 {:original-args nil}]))
+           (is (= [[{:args nil :return -1}]
+                   []]
+                  (:calls @f)))
+           (is (= [] (bond/local-calls dunk)))
+           (is (= [] (bond/local-calls funk)))))))
 
 (deftest thread-safe-stub
-  (let [p (promise)
-        f (future
-            (bond/with-local-stub [dunk [funk (constantly -1)]]
-              (while (not (realized? p))
-                (Thread/sleep 10))
-              {:result [(funk) (dunk)]
-               :calls [(bond/local-calls funk)
-                       (bond/local-calls dunk)]}))]
-    (is (= (funk 9) {:original-args '(9)}))
-    (is (= (dunk 9) {:original-args '(9)}))
-    (deliver p true)
-    (is (= (:result @f) [-1 nil]))
-    (is (= [[{:args nil :return -1}]
-            [{:args nil :return nil}]]
-           (:calls @f)))
-    (is (= [] (bond/local-calls dunk)))
-    (is (= [] (bond/local-calls funk))))
+  #?(:clj
+     (do
+       (let [p (promise)
+             f (future
+                 (bond/with-local-stub [dunk [funk (constantly -1)]]
+                   (while (not (realized? p))
+                     (Thread/sleep 10))
+                   {:result [(funk) (dunk)]
+                    :calls [(bond/local-calls funk)
+                            (bond/local-calls dunk)]}))]
+         (is (= (funk 9) {:original-args '(9)}))
+         (is (= (dunk 9) {:original-args '(9)}))
+         (deliver p true)
+         (is (= (:result @f) [-1 nil]))
+         (is (= [[{:args nil :return -1}]
+                 [{:args nil :return nil}]]
+                (:calls @f)))
+         (is (= [] (bond/local-calls dunk)))
+         (is (= [] (bond/local-calls funk))))
 
-  (let [p (promise)
-        f (future
-            (bond/with-local-stub [[funk (constantly -1)]]
-              (while (not (realized? p))
-                (Thread/sleep 10))
-              {:result [(funk) (dunk)]
-               :calls [(bond/local-calls funk)
-                       (bond/local-calls dunk)]}))]
-    (is (= (funk 9) {:original-args '(9)}))
-    (is (= (dunk 9) {:original-args '(9)}))
-    (deliver p true)
-    (is (= (:result @f) [-1 {:original-args nil}]))
-    (is (= [[{:args nil :return -1}]
-            []]
-           (:calls @f)))
-    (is (= [] (bond/local-calls dunk)))
-    (is (= [] (bond/local-calls funk)))))
+       (let [p (promise)
+             f (future
+                 (bond/with-local-stub [[funk (constantly -1)]]
+                   (while (not (realized? p))
+                     (Thread/sleep 10))
+                   {:result [(funk) (dunk)]
+                    :calls [(bond/local-calls funk)
+                            (bond/local-calls dunk)]}))]
+         (is (= (funk 9) {:original-args '(9)}))
+         (is (= (dunk 9) {:original-args '(9)}))
+         (deliver p true)
+         (is (= (:result @f) [-1 {:original-args nil}]))
+         (is (= [[{:args nil :return -1}]
+                 []]
+                (:calls @f)))
+         (is (= [] (bond/local-calls dunk)))
+         (is (= [] (bond/local-calls funk)))))))
 
 (deftest thread-spy
-  (let [p (promise)
-        f (future
-            (bond/with-local-spy [dunk funk]
-              (while (not (realized? p))
-                (Thread/sleep 10))
-              {:result [(funk) (dunk)]
-               :calls [(bond/local-calls funk)
-                       (bond/local-calls dunk)]}))]
-    (is (= (funk 9) {:original-args '(9)}))
-    (is (= (dunk 9) {:original-args '(9)}))
-    (deliver p true)
-    (is (= (:result @f) [{:original-args nil} {:original-args nil}]))
-    (is (= [[{:args nil :return {:original-args nil}}]
-            [{:args nil :return {:original-args nil}}]]
-           (:calls @f)))
-    (is (= [] (bond/local-calls dunk)))
-    (is (= [] (bond/local-calls funk))))
+  #?(:clj
+     (do (let [p (promise)
+               f (future
+                   (bond/with-local-spy [dunk funk]
+                     (while (not (realized? p))
+                       (Thread/sleep 10))
+                     {:result [(funk) (dunk)]
+                      :calls [(bond/local-calls funk)
+                              (bond/local-calls dunk)]}))]
+           (is (= (funk 9) {:original-args '(9)}))
+           (is (= (dunk 9) {:original-args '(9)}))
+           (deliver p true)
+           (is (= (:result @f) [{:original-args nil} {:original-args nil}]))
+           (is (= [[{:args nil :return {:original-args nil}}]
+                   [{:args nil :return {:original-args nil}}]]
+                  (:calls @f)))
+           (is (= [] (bond/local-calls dunk)))
+           (is (= [] (bond/local-calls funk))))
 
-  (let [p (promise)
-        f (future
-            (bond/with-local-spy [funk]
-              (while (not (realized? p))
-                (Thread/sleep 10))
-              {:result [(funk) (dunk)]
-               :calls [(bond/local-calls funk)
-                       (bond/local-calls dunk)]}))]
-    (is (= (funk 9) {:original-args '(9)}))
-    (is (= (dunk 9) {:original-args '(9)}))
-    (deliver p true)
-    (is (= (:result @f) [{:original-args nil} {:original-args nil}]))
-    (is (= [[{:args nil :return {:original-args nil}}]
-            []]
-           (:calls @f)))
-    (is (= [] (bond/local-calls dunk)))
-    (is (= [] (bond/local-calls funk)))))
+         (let [p (promise)
+               f (future
+                   (bond/with-local-spy [funk]
+                     (while (not (realized? p))
+                       (Thread/sleep 10))
+                     {:result [(funk) (dunk)]
+                      :calls [(bond/local-calls funk)
+                              (bond/local-calls dunk)]}))]
+           (is (= (funk 9) {:original-args '(9)}))
+           (is (= (dunk 9) {:original-args '(9)}))
+           (deliver p true)
+           (is (= (:result @f) [{:original-args nil} {:original-args nil}]))
+           (is (= [[{:args nil :return {:original-args nil}}]
+                   []]
+                  (:calls @f)))
+           (is (= [] (bond/local-calls dunk)))
+           (is (= [] (bond/local-calls funk)))))))
 
 (deftest test-calls
-  (is (fn? bond/local-calls))
-  (bond/with-local-spy [funk dunk]
-    (is (= (mapv bond/local-calls [funk dunk])
-           [(bond/local-calls funk)
-            (bond/local-calls dunk)]
-           (mapv (fn [f] (bond/local-calls f))
-                 [funk dunk])))))
+  #?(:clj
+     (do
+       (is (fn? bond/local-calls))
+       (bond/with-local-spy [funk dunk]
+         (is (= (mapv bond/local-calls [funk dunk])
+                [(bond/local-calls funk)
+                 (bond/local-calls dunk)]
+                (mapv (fn [f] (bond/local-calls f))
+                      [funk dunk])))))))

--- a/test/bond/test/james.cljc
+++ b/test/bond/test/james.cljc
@@ -4,6 +4,9 @@
             [bond.test.target :as target])
   #?(:cljs (:require-macros [cljs.test :refer (is deftest testing)])))
 
+(defn funk [& args] {:original-args args})
+(defn dunk [& args] {:original-args args})
+
 (deftest spy-logs-args-and-results
   (bond/with-spy [target/foo]
     (is (= 2 (target/foo 1)))
@@ -49,7 +52,6 @@
     (testing "spying works"
       (is (= [4] (-> target/foo bond/calls first :args)))
       (is (= [3] (-> target/bar bond/calls first :args))))))
-
 
 (deftest iterator-style-stubbing-works
   (bond/with-stub [target/foo
@@ -103,3 +105,228 @@
     (bond/with-stub-ns [[bond.test.target (constantly 3)]]
       (is (= 3 (target/foo 10)))
       (is (= [10] (-> target/foo bond/calls first :args))))))
+
+(deftest local-spy-logs-args-and-results
+  (bond/with-local-spy [target/foo]
+    (is (= 2 (target/foo 1)))
+    (is (= 4 (target/foo 2)))
+    (is (= [{:args [1] :return 2}
+            {:args [2] :return 4}]
+           (bond/local-calls target/foo)))
+    ;; cljs doesn't throw ArityException
+    #?(:clj (let [exception (is (thrown? clojure.lang.ArityException (target/foo 3 4)))]
+              (is (= {:args [3 4] :throw exception}
+                     (-> target/foo bond/local-calls last)))))))
+
+(deftest local-spy-can-spy-private-fns
+  (bond/with-local-spy [target/private-foo]
+    (is (= 4 (#'target/private-foo 2)))
+    (is (= 6 (#'target/private-foo 3)))
+    (is (= [{:args [2] :return 4}
+            {:args [3] :return 6}]
+           (bond/local-calls #'target/private-foo)))))
+
+(deftest local-stub-works
+  (is (= ""
+         (with-out-str
+           (bond/with-local-stub [target/bar]
+             (target/bar 3))))))
+
+(deftest local-stub-works-with-private-fn
+  (testing "without replacement"
+    (bond/with-local-stub [target/private-foo]
+      (is (nil? (#'target/private-foo 3)))
+      (is (= [3] (-> #'target/private-foo bond/local-calls first :args)))))
+  (testing "with replacement"
+    (bond/with-local-stub [[target/private-foo (fn [x] (* x x))]]
+      (is (= 9 (#'target/private-foo 3)))
+      (is (= [3] (-> #'target/private-foo bond/local-calls first :args))))))
+
+(deftest local-stub-with-replacement-works
+  (bond/with-local-stub [target/foo
+                   [target/bar #(str "arg is " %)]]
+    (testing "stubbing works"
+      (is (nil? (target/foo 4)))
+      (is (= "arg is 3" (target/bar 3))))
+    (testing "spying works"
+      (is (= [4] (-> target/foo bond/local-calls first :args)))
+      (is (= [3] (-> target/bar bond/local-calls first :args))))))
+
+(deftest local-iterator-style-stubbing-works
+  (bond/with-local-stub [target/foo
+                   [target/bar [#(str "first arg is " %)
+                                #(str "second arg is " %)
+                                #(str "third arg is " %)]]]
+    (testing "stubbing works"
+      (is (nil? (target/foo 4)))
+      (is (= "first arg is 3" (target/bar 3)))
+      (is (= "second arg is 4" (target/bar 4)))
+      (is (= "third arg is 5" (target/bar 5))))
+    (testing "spying works"
+      (is (= [4] (-> target/foo bond/local-calls first :args)))
+      (is (= [3] (-> target/bar bond/local-calls first :args)))
+      (is (= [4] (-> target/bar bond/local-calls second :args)))
+      (is (= [5] (-> target/bar bond/local-calls last :args))))))
+
+(deftest local-stub!-complains-loudly-if-there-is-no-arglists
+  (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
+               (bond/with-local-stub! [[target/without-arglists (constantly 42)]]
+                 (is false)))))
+
+(deftest local-stub!-throws-arity-exception
+  (bond/with-local-stub! [[target/foo (constantly 9)]]
+    (is (= 9 (target/foo 12)))
+    (is (= [{:args [12] :return 9}] (bond/local-calls target/foo))))
+  (bond/with-local-stub! [target/bar
+                    target/quuk
+                    [target/quux (fn [_ _ & x] x)]]
+    (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
+                 (target/bar 1 2)))
+    (is (thrown? #?(:clj clojure.lang.ArityException :cljs js/Error)
+                 (target/quuk 1)))
+    (is (= [6 5] (target/quux 8 7 6 5)))))
+
+(deftest local-spying-entire-namespaces-works
+  (bond/with-local-spy-ns [bond.test.target]
+    (target/foo 1)
+    (target/foo 2)
+    (is (= [{:args [1] :return 2}
+            {:args [2] :return 4}]
+           (bond/local-calls target/foo)))
+    (is (= 0 (-> target/bar bond/local-calls count)))))
+
+(deftest test-with-dynamic-redefs
+  (dotimes [i 100]
+    (let [f1 (future (bond/with-dynamic-redefs [funk (constantly -100)]
+                       (Thread/sleep (rand-int 100))
+                       {:100 (funk) :t (.getName (Thread/currentThread))}))
+
+          f2 (future (bond/with-dynamic-redefs [funk (constantly -200)]
+                       (Thread/sleep (rand-int 100))
+                       {:200 (funk 9) :t (.getName (Thread/currentThread))}))
+          f3 (future (do
+                       (Thread/sleep (rand-int 100))
+                       {:orig (funk 9) :t (.getName (Thread/currentThread))}))]
+      (is (and (= (:100 @f1) -100)
+               (= (:200 @f2) -200)
+               (= (:orig @f3) {:original-args '(9)}))))))
+
+(deftest thread-safe-stub!
+  (let [p (promise)
+        f (future
+            (bond/with-local-stub! [dunk [funk (constantly -1)]]
+              (while (not (realized? p))
+                (Thread/sleep 10))
+              {:result [(funk) (dunk)]
+               :calls [(bond/local-calls funk)
+                       (bond/local-calls dunk)]}))]
+    (is (= (funk 9) {:original-args '(9)}))
+    (is (= (dunk 9) {:original-args '(9)}))
+    (deliver p true)
+    (is (= (:result @f) [-1 nil]))
+    (is (= [[{:args nil :return -1}]
+            [{:args nil :return nil}]]
+           (:calls @f)))
+    (is (= [] (bond/local-calls dunk)))
+    (is (= [] (bond/local-calls funk))))
+
+  (let [p (promise)
+        f (future
+            (bond/with-local-stub! [[funk (constantly -1)]]
+              (while (not (realized? p))
+                (Thread/sleep 10))
+              {:result [(funk) (dunk)]
+               :calls [(bond/local-calls funk)
+                       (bond/local-calls dunk)]}))]
+    (is (= (funk 9) {:original-args '(9)}))
+    (is (= (dunk 9) {:original-args '(9)}))
+    (deliver p true)
+    (is (= (:result @f) [-1 {:original-args nil}]))
+    (is (= [[{:args nil :return -1}]
+            []]
+           (:calls @f)))
+    (is (= [] (bond/local-calls dunk)))
+    (is (= [] (bond/local-calls funk)))))
+
+(deftest thread-safe-stub
+  (let [p (promise)
+        f (future
+            (bond/with-local-stub [dunk [funk (constantly -1)]]
+              (while (not (realized? p))
+                (Thread/sleep 10))
+              {:result [(funk) (dunk)]
+               :calls [(bond/local-calls funk)
+                       (bond/local-calls dunk)]}))]
+    (is (= (funk 9) {:original-args '(9)}))
+    (is (= (dunk 9) {:original-args '(9)}))
+    (deliver p true)
+    (is (= (:result @f) [-1 nil]))
+    (is (= [[{:args nil :return -1}]
+            [{:args nil :return nil}]]
+           (:calls @f)))
+    (is (= [] (bond/local-calls dunk)))
+    (is (= [] (bond/local-calls funk))))
+
+  (let [p (promise)
+        f (future
+            (bond/with-local-stub [[funk (constantly -1)]]
+              (while (not (realized? p))
+                (Thread/sleep 10))
+              {:result [(funk) (dunk)]
+               :calls [(bond/local-calls funk)
+                       (bond/local-calls dunk)]}))]
+    (is (= (funk 9) {:original-args '(9)}))
+    (is (= (dunk 9) {:original-args '(9)}))
+    (deliver p true)
+    (is (= (:result @f) [-1 {:original-args nil}]))
+    (is (= [[{:args nil :return -1}]
+            []]
+           (:calls @f)))
+    (is (= [] (bond/local-calls dunk)))
+    (is (= [] (bond/local-calls funk)))))
+
+(deftest thread-spy
+  (let [p (promise)
+        f (future
+            (bond/with-local-spy [dunk funk]
+              (while (not (realized? p))
+                (Thread/sleep 10))
+              {:result [(funk) (dunk)]
+               :calls [(bond/local-calls funk)
+                       (bond/local-calls dunk)]}))]
+    (is (= (funk 9) {:original-args '(9)}))
+    (is (= (dunk 9) {:original-args '(9)}))
+    (deliver p true)
+    (is (= (:result @f) [{:original-args nil} {:original-args nil}]))
+    (is (= [[{:args nil :return {:original-args nil}}]
+            [{:args nil :return {:original-args nil}}]]
+           (:calls @f)))
+    (is (= [] (bond/local-calls dunk)))
+    (is (= [] (bond/local-calls funk))))
+
+  (let [p (promise)
+        f (future
+            (bond/with-local-spy [funk]
+              (while (not (realized? p))
+                (Thread/sleep 10))
+              {:result [(funk) (dunk)]
+               :calls [(bond/local-calls funk)
+                       (bond/local-calls dunk)]}))]
+    (is (= (funk 9) {:original-args '(9)}))
+    (is (= (dunk 9) {:original-args '(9)}))
+    (deliver p true)
+    (is (= (:result @f) [{:original-args nil} {:original-args nil}]))
+    (is (= [[{:args nil :return {:original-args nil}}]
+            []]
+           (:calls @f)))
+    (is (= [] (bond/local-calls dunk)))
+    (is (= [] (bond/local-calls funk)))))
+
+(deftest test-calls
+  (is (fn? bond/local-calls))
+  (bond/with-local-spy [funk dunk]
+    (is (= (mapv bond/local-calls [funk dunk])
+           [(bond/local-calls funk)
+            (bond/local-calls dunk)]
+           (mapv (fn [f] (bond/local-calls f))
+                 [funk dunk])))))


### PR DESCRIPTION
`with-stub` and `wih-spy` functions alter the root of the Var of the
function, through with-redefs, which makes this redefinition visible
to all threads.

Now we provide local versions of `with-stub` and `with-spy` which function
the same way as the normal versions but the changes are only visible
to the currently running thread. Other threads see the original
redefinitons or their own redefinitions.

This only works for threads which respect the Clojure per-thread
bindings, and thus won't work for other concurrency primitives like
java.lang.Thread.

This is for https://github.com/circleci/bond/issues/45