### PR TITLE
bump 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bond [![CircleCI Status](https://circleci.com/gh/circleci/bond.png?style=badge)]
 Bond is a spying and stubbing library, primarily intended for tests.
 
 ```clojure
-[circleci/bond "0.3.1"]
+[circleci/bond "0.4.0"]
 ```
 
 ```clojure

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject circleci/bond "0.3.2"
+(defproject circleci/bond "0.4.0"
   :description "Spying library for testing"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}


### PR DESCRIPTION
I will `tag 0.4.0` and release to clojars when merged.