### PR TITLE
Release version 0.5.0 with automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,33 @@ jobs:
             - ~/.m2
       - store_artifacts:
           path: target/coverage
+  publish:
+    docker:
+      - image: clojure:lein-2.7.1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - clj-jars-v2-{{ checksum "project.clj" }}
+            - clj-jars-v2-
+      - run:
+          name: Download dependencies
+          command: lein deps
+      - run:
+          name: Publish to clojars
+          command: lein deploy
 
 workflows:
   version: 2
-  test:
+  test-and-publish:
     jobs:
       - test
+      - publish:
+          context: clojars-publish
+          requires:
+            - test
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0]
 ### Removed
 - Support for ClojureScript. Please pin to 0.4.0 if you need it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Removed
+- Support for ClojureScript. Please pin to 0.4.0 if you need it.
+
+### Changed
+- `bond.james/calls` throws an exception if the function hasn't been spied or stubbed.
+- Tests against Clojure 1.10 (bumped from 1.7).
+
+## [0.4.0]
+### Added
+- New assertions `called?`, `called-times?`, and `called-with-args?`.
+
+## [0.3.2]
+### Changed
+- `bond.james/stub!` and `bond.james/with-stub!` throw with an explanation when `:argslist` is missing.
+
+## [0.3.1]
+### Added
+- Improved support for stubbing private functions.
+
+### Changed
+- Removed runtime dependencies on Clojure and ClojureScript.
+
+## [0.3.0]
+### Added
+- `bond.james/with-stub!` which throws an exception when there's an arity mismatch.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ and `with-stub-ns` which can spy/stub every function in a namespace in one go:
     (is (= :baz (bar)))))
 ```
 
+Releasing
+---------
+
+New git tags are automatically published to [clojars](https://clojars.org/circleci/bond).
+
+The following should be updated on the main/master branch before tagging:
+
+- `project.clj` - version
+- `README.md` - dependency coordinates
+- `CHANGELOG.md` - summary of changes
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bond [![CircleCI Status](https://circleci.com/gh/circleci/bond.png?style=badge)]
 Bond is a spying and stubbing library, primarily intended for tests.
 
 ```clojure
-[circleci/bond "0.4.0"]
+[circleci/bond "0.5.0"]
 ```
 
 ```clojure

--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,12 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies []
   :plugins [[lein-cloverage "1.2.2"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.2"]]}})
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.2"]]}}
+  :repositories [["releases" {:url "https://clojars.org/repo"
+                              :username :env/clojars_username
+                              :password :env/clojars_token
+                              :sign-releases false}]
+                 ["snapshots" {:url "https://clojars.org/repo"
+                               :username :env/clojars_username
+                               :password :env/clojars_token
+                               :sign-releases false}]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject circleci/bond "0.4.0"
+(defproject circleci/bond "0.5.0"
   :description "Spying library for testing"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}


### PR DESCRIPTION
So that we don't need to find credentials and remember how to release
changes manually. Git tags are used to trigger publishing so that we
don't re-publish over existing versions every time we merge to master.
It also means that we're more likely to remember to tag and don't need
to add any logic or credentials for the workflow to create tags.

An alternative would have been to use the build number as a patch
version, but it's unwieldy for both for users and for us to maintain the
versions in `README.md` and `CHANGELOG.md`.

The `CLOJARS_USERNAME` and `CLOJARS_TOKEN` environment variables have
been added to the project. At the moment they belong to an individual
but we'll move them to a machine user later. The project already has
"build forks" and "pass secrets to fork builds" disabled, which will
prevent leaking these credentials.

---

Depends on #53 and #54.