### PR TITLE
Upgrade Clojure and Cloverage versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies []
-  :plugins [[lein-cloverage "1.0.9"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
-                                  ;; by default, lein-cloverage will
-                                  ;; use the latest release of
-                                  ;; cloverage. Specify the version of
-                                  ;; cloverage to override this.
-                                  [cloverage "1.0.9"]]}})
+  :plugins [[lein-cloverage "1.2.2"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.2"]]}})

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies []
-  :plugins [[lein-test-out "0.3.1" :exclusions [org.clojure/clojure]]
-            [lein-cloverage "1.0.9"]]
+  :plugins [[lein-cloverage "1.0.9"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
                                   ;; by default, lein-cloverage will
                                   ;; use the latest release of


### PR DESCRIPTION
So that we test against a more recent and representative version of
Clojure and no longer need to pin an older version of Cloverage for
compatibility with it.

Depends (and is based on) https://github.com/circleci/bond/pull/53