### PR TITLE
ci: Add tag filter to test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,10 @@ workflows:
   version: 2
   test-and-publish:
     jobs:
-      - test
+      - test:
+          filters:
+            tags:
+              only: /.*/
       - publish:
           context: clojars-publish
           requires:


### PR DESCRIPTION
In order to allow `publish` to run on a tag. Previously the tag I pushed
resulted in "no workflow" because of: (https://circleci.com/docs/2.0/configuration-reference/#tags)

> Additionally, if a job requires any other jobs (directly or indirectly), you must specify tag filters for those jobs.

I've deleted the `0.5.0` tag that I previously created and will recreate
it after this change. This isn't great form, as tags should be
immutable, but it won't have been used for anything yet and doesn't
warrant bumping the version because we failed to release it.