### PR TITLE
don't specify codecov file parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,7 @@ jobs:
       - run:
           name: Code Coverage
           command: lein cloverage --codecov
-      - codecov/upload:
-          file: target/coverage/codecov.json
+      - codecov/upload
       - save_cache:
           key: clj-jars-v2-{{ checksum "project.clj" }}
           paths:


### PR DESCRIPTION
`*coverage*.*` pattern is scooped in the default setup

cf https://github.com/codecov/codecov-bash/blob/ce0eb066b997622ff071255e8aa4c239099c17fc/codecov#L1297