### PR TITLE
[SRE-3660] Update the Codecov orb to 1.2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.1.3
+  codecov: codecov/codecov@1.2.2
 
 jobs:
   clj-kondo:


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos