### PR TITLE
Add called-once-with-args? and called-at-least-once-with-args? to bond/assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0]
+### Added
+- New assertions `called-once-with-args?` and `called-at-least-once-with-args?`.
+
 ## [0.5.0]
 ### Removed
 - Support for ClojureScript. Please pin to 0.4.0 if you need it.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bond [![CircleCI Status](https://circleci.com/gh/circleci/bond.png?style=badge)]
 Bond is a spying and stubbing library, primarily intended for tests.
 
 ```clojure
-[circleci/bond "0.5.0"]
+[circleci/bond "0.6.0"]
 ```
 
 ```clojure

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject circleci/bond "0.5.0"
+(defproject circleci/bond "0.6.0"
   :description "Spying library for testing"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/bond/assertions.clj
+++ b/src/bond/assertions.clj
@@ -24,8 +24,7 @@
    
    `args` should be a vector/coll of args [arg1 arg2 arg3] to compare directly to the value of `:args` from `bond/calls`"
   [f args]
-  (and (called-times? f 1)
-       (called-with-args? f [args])))
+  (called-with-args? f [args]))
 
 (defn called-at-least-once-with-args?
   "An assertion to check if `f` has been called at least once with `args`.

--- a/src/bond/assertions.clj
+++ b/src/bond/assertions.clj
@@ -17,3 +17,19 @@
   `vargs` should be a vector of args [args-first-call args-second-call ...] to allow for the checking of multiple calls of `f`."
   [f vargs]
   (= vargs (->> f bond/calls (mapv :args))))
+
+(defn called-once-with-args?
+  "An assertion to check if `f` was called with `args` strictly once.
+   
+   `args` should be a vector/coll of args [arg1 arg2 arg3] to compare directly to the value of `:args` from `bond/calls`"
+  [f args]
+  (and (called-times? f 1)
+       (= args (-> f bond/calls first :args))))
+
+(defn called-at-least-once-with-args?
+  "An assertion to check if `f` has been called at least once with `args`.
+
+   `args` should be a vector/coll of args [arg1 arg2 {:arg3 arg3}] to compare directly to the value of `:args` from `bond/calls`"
+  [f args]
+  (let [all-calls (into #{} (map :args (bond/calls f)))]
+    (contains? all-calls args)))

--- a/src/bond/assertions.clj
+++ b/src/bond/assertions.clj
@@ -14,7 +14,8 @@
 (defn called-with-args?
   "An assertion to check if `f` was called with `vargs`.
 
-  `vargs` should be a vector of args [args-first-call args-second-call ...] to allow for the checking of multiple calls of `f`."
+  `vargs` should be a vector of args [args-first-call args-second-call ...] to allow for the checking of multiple calls of `f`.
+   Note that this method asserts about every call to `f`."
   [f vargs]
   (= vargs (->> f bond/calls (mapv :args))))
 
@@ -24,12 +25,12 @@
    `args` should be a vector/coll of args [arg1 arg2 arg3] to compare directly to the value of `:args` from `bond/calls`"
   [f args]
   (and (called-times? f 1)
-       (= args (-> f bond/calls first :args))))
+       (called-with-args? f [args])))
 
 (defn called-at-least-once-with-args?
   "An assertion to check if `f` has been called at least once with `args`.
 
    `args` should be a vector/coll of args [arg1 arg2 {:arg3 arg3}] to compare directly to the value of `:args` from `bond/calls`"
   [f args]
-  (let [all-calls (into #{} (map :args (bond/calls f)))]
-    (contains? all-calls args)))
+  (boolean (some (fn [call] (= (:args call) args))
+                 (bond/calls f))))

--- a/test/bond/assertions_test.clj
+++ b/test/bond/assertions_test.clj
@@ -27,7 +27,7 @@
   (testing "the number of times a spy was called"
     (bond/with-spy [target/foo]
       (let [_ (target/foo-caller 1)]
-        (is (assertions/called-times? target/foo 1 )))
+        (is (assertions/called-times? target/foo 1)))
       (let [_ (target/foo 2)]
         (is (assertions/called-times? target/foo 2)))))
 
@@ -61,3 +61,54 @@
   (testing "called-with-args? fails when its argument is not spied"
     (is (thrown? IllegalArgumentException
                  (assertions/called-with-args? target/foo [])))))
+
+(deftest called-once-with-args?-works
+  (testing "an assertion for calling a spy once with args"
+    (bond/with-spy [target/foo]
+      (let [_ (target/foo 1)]
+        (is (assertions/called-once-with-args? target/foo [1]))
+        (is (not (assertions/called-once-with-args? target/foo [2]))))))
+
+  (testing "an assertion for calling a spy indirectly once with args"
+    (bond/with-spy [target/foo]
+      (let [_ (target/foo-caller 1)]
+        (is (assertions/called-once-with-args? target/foo [1]))
+        (is (not (assertions/called-once-with-args? target/foo [2]))))))
+
+  (testing "an assertion for a spy that was not called"
+    (bond/with-spy [target/foo]
+      (is (not (assertions/called-once-with-args? target/foo [])))))
+
+  (testing "called-once-with-args? fails when its argument is not spied"
+    (is (thrown? IllegalArgumentException
+                 (assertions/called-once-with-args? target/foo [])))))
+
+(deftest called-at-least-once-with-args?-works
+  (testing "an assertion for calling a spy multiple times"
+    (bond/with-spy [target/foo]
+      (let [_ (do (target/foo 1)
+                  (target/foo 2))]
+        (is (assertions/called-at-least-once-with-args? target/foo [1]))
+        (is (assertions/called-at-least-once-with-args? target/foo [2]))
+        (is (not (assertions/called-at-least-once-with-args? target/foo [3]))))))
+
+  (testing "an assertion for calling a spy multiple times with the same value"
+    (bond/with-spy [target/foo]
+      (let [_ (do (target/foo 1)
+                  (target/foo 1))]
+        (is (assertions/called-at-least-once-with-args? target/foo [1]))
+        (is (not (assertions/called-at-least-once-with-args? target/foo [2]))))))
+
+  (testing "an assertion for calling a spy once"
+    (bond/with-spy [target/foo]
+      (let [_ (target/foo 1)]
+        (is (assertions/called-at-least-once-with-args? target/foo [1]))
+        (is (not (assertions/called-at-least-once-with-args? target/foo [2]))))))
+
+  (testing "an assertion for a spy that was not called"
+    (bond/with-spy [target/foo]
+      (is (not (assertions/called-at-least-once-with-args? target/foo [])))))
+
+  (testing "called-at-least-once-with-args? fails when its argument is not spied"
+    (is (thrown? IllegalArgumentException
+                 (assertions/called-at-least-once-with-args? target/foo [])))))

--- a/test/bond/assertions_test.clj
+++ b/test/bond/assertions_test.clj
@@ -7,13 +7,13 @@
 (deftest called?-works
   (testing "a spy was called directly"
     (bond/with-spy [target/foo]
-      (let [_ (target/foo 1)]
-        (is (assertions/called? target/foo)))))
+      (target/foo 1)
+      (is (assertions/called? target/foo))))
 
   (testing "a spy was called indirectly"
     (bond/with-spy [target/foo]
-      (let [_ (target/foo-caller 1)]
-        (is (assertions/called? target/foo)))))
+      (target/foo-caller 1)
+      (is (assertions/called? target/foo))))
 
   (testing "a spy was not called"
     (bond/with-spy [target/foo]
@@ -26,17 +26,17 @@
 (deftest called-times?-works
   (testing "the number of times a spy was called"
     (bond/with-spy [target/foo]
-      (let [_ (target/foo-caller 1)]
-        (is (assertions/called-times? target/foo 1)))
-      (let [_ (target/foo 2)]
-        (is (assertions/called-times? target/foo 2)))))
+      (target/foo-caller 1)
+      (is (assertions/called-times? target/foo 1))
+      (target/foo 2)
+      (is (assertions/called-times? target/foo 2))))
 
   (testing "the number of times a spy was not called"
     (bond/with-spy [target/foo]
-      (let [_ (target/foo-caller 1)]
-        (is (not (assertions/called-times? target/foo 2))))
-      (let [_ (target/foo-caller 2)]
-        (is (not (assertions/called-times? target/foo 1))))))
+      (target/foo-caller 1)
+      (is (not (assertions/called-times? target/foo 2)))
+      (target/foo-caller 2)
+      (is (not (assertions/called-times? target/foo 1)))))
 
   (testing "called-times? fails when its argument is not spied"
     (is (thrown? IllegalArgumentException
@@ -46,17 +46,17 @@
   (testing "an assertion for calling a spy with args"
     (bond/with-spy [target/foo
                     target/bar]
-      (let [_ (target/foo-caller 1)]
-        (is (assertions/called-with-args? target/foo [[1]]))
-        (is (not (assertions/called-with-args? target/foo [[2]])))
-        (is (not (assertions/called-with-args? target/bar [[1]])))
-        (is (not (assertions/called-with-args? target/foo [[1 2]]))))))
+      (target/foo-caller 1)
+      (is (assertions/called-with-args? target/foo [[1]]))
+      (is (not (assertions/called-with-args? target/foo [[2]])))
+      (is (not (assertions/called-with-args? target/bar [[1]])))
+      (is (not (assertions/called-with-args? target/foo [[1 2]])))))
 
   (testing "an assertion for calling a spy multiple times with args"
     (bond/with-spy [target/foo]
-      (let [_ (do (target/foo-caller 1)
-                  (target/foo-caller 2))]
-        (is (assertions/called-with-args? target/foo [[1] [2]])))))
+      (target/foo-caller 1)
+      (target/foo-caller 2)
+      (is (assertions/called-with-args? target/foo [[1] [2]]))))
 
   (testing "called-with-args? fails when its argument is not spied"
     (is (thrown? IllegalArgumentException
@@ -65,15 +65,22 @@
 (deftest called-once-with-args?-works
   (testing "an assertion for calling a spy once with args"
     (bond/with-spy [target/foo]
-      (let [_ (target/foo 1)]
-        (is (assertions/called-once-with-args? target/foo [1]))
-        (is (not (assertions/called-once-with-args? target/foo [2]))))))
+      (target/foo 1)
+      (is (assertions/called-once-with-args? target/foo [1]))
+      (is (not (assertions/called-once-with-args? target/foo [2])))))
+
+  (testing "an assertion for calling a spy twice with args"
+    (bond/with-spy [target/foo]
+      (target/foo 1)
+      (target/foo 2)
+      (is (not (assertions/called-once-with-args? target/foo [1])))
+      (is (not (assertions/called-once-with-args? target/foo [2])))))
 
   (testing "an assertion for calling a spy indirectly once with args"
     (bond/with-spy [target/foo]
-      (let [_ (target/foo-caller 1)]
-        (is (assertions/called-once-with-args? target/foo [1]))
-        (is (not (assertions/called-once-with-args? target/foo [2]))))))
+      (target/foo-caller 1)
+      (is (assertions/called-once-with-args? target/foo [1]))
+      (is (not (assertions/called-once-with-args? target/foo [2])))))
 
   (testing "an assertion for a spy that was not called"
     (bond/with-spy [target/foo]
@@ -86,24 +93,24 @@
 (deftest called-at-least-once-with-args?-works
   (testing "an assertion for calling a spy multiple times"
     (bond/with-spy [target/foo]
-      (let [_ (do (target/foo 1)
-                  (target/foo 2))]
-        (is (assertions/called-at-least-once-with-args? target/foo [1]))
-        (is (assertions/called-at-least-once-with-args? target/foo [2]))
-        (is (not (assertions/called-at-least-once-with-args? target/foo [3]))))))
+      (target/foo 1)
+      (target/foo 2)
+      (is (assertions/called-at-least-once-with-args? target/foo [1]))
+      (is (assertions/called-at-least-once-with-args? target/foo [2]))
+      (is (not (assertions/called-at-least-once-with-args? target/foo [3])))))
 
   (testing "an assertion for calling a spy multiple times with the same value"
     (bond/with-spy [target/foo]
-      (let [_ (do (target/foo 1)
-                  (target/foo 1))]
-        (is (assertions/called-at-least-once-with-args? target/foo [1]))
-        (is (not (assertions/called-at-least-once-with-args? target/foo [2]))))))
+      (target/foo 1)
+      (target/foo 1)
+      (is (assertions/called-at-least-once-with-args? target/foo [1]))
+      (is (not (assertions/called-at-least-once-with-args? target/foo [2])))))
 
   (testing "an assertion for calling a spy once"
     (bond/with-spy [target/foo]
-      (let [_ (target/foo 1)]
-        (is (assertions/called-at-least-once-with-args? target/foo [1]))
-        (is (not (assertions/called-at-least-once-with-args? target/foo [2]))))))
+      (target/foo 1)
+      (is (assertions/called-at-least-once-with-args? target/foo [1]))
+      (is (not (assertions/called-at-least-once-with-args? target/foo [2])))))
 
   (testing "an assertion for a spy that was not called"
     (bond/with-spy [target/foo]


### PR DESCRIPTION
On insights we noticed that the assertions available were often not flexible enough for us, and `called-with-args` is confusing without inspecting the source, and not useful on functions that are called many times through the course of a test (`tracing/` methods, for example).

This adds `called-once-with-args` which we've written and use on Insights. We recognize that the same effect can be achieved with `called-with-args` and only providing the set of args we expect, but we've found the name and behaviour of the function confusing.

This also adds `called-at-least-once-with-args?` which is what we had expected `called-with-args` to be. This checks that the `f` provided was called with the provided arguments at least once.

I'd like to propose changing the `called-with-args` doc string to be more explicit about where and how it should be used, but wanted to propose this as a solution on it's own first.